### PR TITLE
LunaChatチャンネルが存在しない時にエラーになる問題を解消

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>RyuZUPluginChat</groupId>
   <artifactId>RyuZUPluginChat</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>RyuZUPluginChat</name>

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
@@ -41,6 +41,10 @@ public class MessageProcessor {
     LunaChatAPI api = LunaChat.getAPI();
     Channel channel = api.getChannel(data.getLunaChatChannelName());
 
+    if (channel == null) {
+      return;
+    }
+
     if (data.isFromDiscord()) {
       Bukkit.getOnlinePlayers().stream()
           .filter(p -> channel.getMembers().stream()


### PR DESCRIPTION
* Nullチェックを追加してLunaChatチャンネルが存在しない時にエラーが出ないように対応