### PR TITLE
#40 に対応 / 個人チャットが届かなかった場合の処理を適用

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>RyuZUPluginChat</groupId>
   <artifactId>RyuZUPluginChat</artifactId>
-  <version>1.4.4</version>
+  <version>1.4.5</version>
   <packaging>jar</packaging>
 
   <name>RyuZUPluginChat</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>RyuZUPluginChat</groupId>
   <artifactId>RyuZUPluginChat</artifactId>
-  <version>1.4.3</version>
+  <version>1.4.4</version>
   <packaging>jar</packaging>
 
   <name>RyuZUPluginChat</name>

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/RyuZUPluginChat.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/RyuZUPluginChat.java
@@ -21,8 +21,8 @@ import ryuzupluginchat.ryuzupluginchat.discord.DiscordHandler;
 import ryuzupluginchat.ryuzupluginchat.discord.DiscordMessageConnection;
 import ryuzupluginchat.ryuzupluginchat.listener.ChatListener;
 import ryuzupluginchat.ryuzupluginchat.listener.JoinQuitListener;
-import ryuzupluginchat.ryuzupluginchat.listener.OutdatedCommandCaptureListener;
 import ryuzupluginchat.ryuzupluginchat.listener.LunaChatHideCommandListener;
+import ryuzupluginchat.ryuzupluginchat.listener.OutdatedCommandCaptureListener;
 import ryuzupluginchat.ryuzupluginchat.message.JsonDataConverter;
 import ryuzupluginchat.ryuzupluginchat.message.MessageDataFactory;
 import ryuzupluginchat.ryuzupluginchat.message.MessageProcessor;
@@ -72,6 +72,8 @@ public final class RyuZUPluginChat extends JavaPlugin {
     messageProcessor = new MessageProcessor(this);
     jsonDataConverter = new JsonDataConverter(this);
     privateChatResponseWaiter = new PrivateChatResponseWaiter(this);
+
+    privateChatResponseWaiter.runTimeoutDetectTask(this);
 
     setupRedisConnections();
 

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
@@ -85,7 +85,18 @@ public class MessageProcessor {
   }
 
   public void processPrivateMessage(PrivateMessageData data) {
+    String receiverName = plugin.getPlayerUUIDMapContainer()
+        .getNameFromUUID(data.getReceivedPlayerUUID());
+    if (receiverName != null) {
+      data.setReceivedPlayerName(receiverName);
+    }
     String message = data.format();
+
+    Bukkit.getOnlinePlayers().stream()
+        .filter(p -> p.hasPermission("rpc.op"))
+        .filter(p -> !p.getUniqueId().equals(data.getReceivedPlayerUUID())
+            && !p.getName().equalsIgnoreCase(data.getSentPlayerName()))
+        .forEach(p -> p.sendMessage(message));
 
     Player targetPlayer = Bukkit.getPlayer(data.getReceivedPlayerUUID());
     if (targetPlayer == null) {

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/message/MessageProcessor.java
@@ -92,11 +92,13 @@ public class MessageProcessor {
     }
     String message = data.format();
 
-    Bukkit.getOnlinePlayers().stream()
-        .filter(p -> p.hasPermission("rpc.op"))
-        .filter(p -> !p.getUniqueId().equals(data.getReceivedPlayerUUID())
-            && !p.getName().equalsIgnoreCase(data.getSentPlayerName()))
-        .forEach(p -> p.sendMessage(message));
+    if (receiverName != null) {
+      Bukkit.getOnlinePlayers().stream()
+          .filter(p -> p.hasPermission("rpc.op"))
+          .filter(p -> !p.getUniqueId().equals(data.getReceivedPlayerUUID())
+              && !p.getName().equalsIgnoreCase(data.getSentPlayerName()))
+          .forEach(p -> p.sendMessage(message));
+    }
 
     Player targetPlayer = Bukkit.getPlayer(data.getReceivedPlayerUUID());
     if (targetPlayer == null) {

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/MessageSubscriber.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/MessageSubscriber.java
@@ -36,7 +36,13 @@ public class MessageSubscriber {
         if (channel.equals("rpc:" + groupName + ":global-chat")) {
           GlobalMessageData data = converter.convertIntoGlobalMessageData(message);
           if (data != null) {
-            globalChannelConsumers.forEach(c -> c.accept(data));
+            globalChannelConsumers.forEach(c -> {
+              try {
+                c.accept(data);
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+            });
           } else {
             // TODO error log
           }
@@ -44,7 +50,13 @@ public class MessageSubscriber {
         } else if (channel.equals("rpc:" + groupName + ":private-chat")) {
           PrivateMessageData data = converter.convertIntoPrivateMessageData(message);
           if (data != null) {
-            privateChatConsumers.forEach(c -> c.accept(data));
+            privateChatConsumers.forEach(c -> {
+              try {
+                c.accept(data);
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+            });
           } else {
             // TODO error log
           }
@@ -52,7 +64,13 @@ public class MessageSubscriber {
         } else if (channel.equals("rpc:" + groupName + ":channel-chat")) {
           ChannelChatMessageData data = converter.convertIntoChannelChatMessageData(message);
           if (data != null) {
-            channelChatConsumers.forEach(c -> c.accept(data));
+            channelChatConsumers.forEach(c -> {
+              try {
+                c.accept(data);
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+            });
           } else {
             // TODO error log
           }
@@ -60,7 +78,13 @@ public class MessageSubscriber {
         } else if (channel.equals("rpc:" + groupName + ":system-message")) {
           SystemMessageData data = converter.convertIntoSystemMessageData(message);
           if (data != null) {
-            systemMessageConsumers.forEach(c -> c.accept(data));
+            systemMessageConsumers.forEach(c -> {
+              try {
+                c.accept(data);
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+            });
           } else {
             // TODO error log
           }

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PlayerUUIDMapContainer.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PlayerUUIDMapContainer.java
@@ -70,7 +70,7 @@ public class PlayerUUIDMapContainer {
       } catch (IllegalArgumentException e) {
         plugin.getLogger()
             .warning(
-                "Invalid string uuid has been responded from Redis server. ( " + uuidStr + " )");
+                "Received invalid UUID from Redis server ( " + uuidStr + " )");
         return null;
       }
     } finally {

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PlayerUUIDMapContainer.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PlayerUUIDMapContainer.java
@@ -1,10 +1,12 @@
 package ryuzupluginchat.ryuzupluginchat.redis;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.entity.Player;
 import redis.clients.jedis.Jedis;
@@ -19,11 +21,20 @@ public class PlayerUUIDMapContainer {
 
   private final String groupName;
 
-  private Map<String, String> playerCache;
+  private Map<String, String> playerCache = new HashMap<>();
   private long lastCacheUpdated;
+
+  private final ReentrantLock lock = new ReentrantLock(true);
 
   public void register(String name, UUID uuid) {
     jedis.hset("rpc:" + groupName + ":uuid-map", name.toLowerCase(Locale.ROOT), uuid.toString());
+
+    lock.lock();
+    try {
+      playerCache.put(name.toLowerCase(Locale.ROOT), uuid.toString());
+    } finally {
+      lock.unlock();
+    }
   }
 
   public void register(Player p) {
@@ -32,6 +43,13 @@ public class PlayerUUIDMapContainer {
 
   public void unregister(String name) {
     jedis.hdel("rpc:" + groupName + ":uuid-map", name.toLowerCase());
+
+    lock.lock();
+    try {
+      playerCache.remove(name.toLowerCase(Locale.ROOT));
+    } finally {
+      lock.unlock();
+    }
   }
 
   public void unregister(Player p) {
@@ -39,36 +57,60 @@ public class PlayerUUIDMapContainer {
   }
 
   public UUID getUUID(String name) {
-    String value = jedis.hget("rpc:" + groupName + ":uuid-map", name.toLowerCase());
-    if (value == null) {
-      return null;
-    }
+    updateCacheIfOutdated();
+    lock.lock();
     try {
-      return UUID.fromString(value);
-    } catch (IllegalArgumentException e) {
-      plugin.getLogger()
-          .warning("Invalid string uuid has been responded from Redis server. ( " + value + " )");
-      return null;
+      String uuidStr = playerCache.getOrDefault(name, null);
+
+      if (uuidStr == null) {
+        return null;
+      }
+      try {
+        return UUID.fromString(uuidStr);
+      } catch (IllegalArgumentException e) {
+        plugin.getLogger()
+            .warning(
+                "Invalid string uuid has been responded from Redis server. ( " + uuidStr + " )");
+        return null;
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
   public Set<String> getAllNames() {
     updateCacheIfOutdated();
-    return new HashSet<>(playerCache.keySet());
+    lock.lock();
+    try {
+      return new HashSet<>(playerCache.keySet());
+    } finally {
+      lock.unlock();
+    }
   }
 
   public boolean isOnline(UUID uuid) {
     updateCacheIfOutdated();
-    return playerCache.containsValue(uuid.toString());
+    lock.lock();
+    try {
+      return playerCache.containsValue(uuid.toString());
+    } finally {
+      lock.unlock();
+    }
   }
 
   public String getNameFromUUID(UUID uuid) {
     updateCacheIfOutdated();
-    for (String name : playerCache.keySet()) {
-      String uuidStr = playerCache.get(name);
-      if (uuidStr.equals(uuid.toString())) {
-        return name;
+
+    lock.lock();
+    try {
+      for (String name : playerCache.keySet()) {
+        String uuidStr = playerCache.get(name);
+        if (uuidStr.equals(uuid.toString())) {
+          return name;
+        }
       }
+    } finally {
+      lock.unlock();
     }
 
     return null;
@@ -76,8 +118,13 @@ public class PlayerUUIDMapContainer {
 
   private void updateCacheIfOutdated() {
     if (lastCacheUpdated + 5000L < System.currentTimeMillis()) {
-      playerCache = jedis.hgetAll("rpc:" + groupName + ":uuid-map");
-      lastCacheUpdated = System.currentTimeMillis();
+      lock.lock();
+      try {
+        playerCache = jedis.hgetAll("rpc:" + groupName + ":uuid-map");
+        lastCacheUpdated = System.currentTimeMillis();
+      } finally {
+        lock.unlock();
+      }
     }
   }
 }

--- a/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PrivateChatResponseWaiter.java
+++ b/src/main/java/ryuzupluginchat/ryuzupluginchat/redis/PrivateChatResponseWaiter.java
@@ -15,8 +15,8 @@ public class PrivateChatResponseWaiter {
 
   private final RyuZUPluginChat plugin;
 
-  private HashMap<Long, PrivateMessageData> dataMap = new HashMap<>();
-  private HashMap<Long, Long> timeouts = new HashMap<>();
+  private final HashMap<Long, PrivateMessageData> dataMap = new HashMap<>();
+  private final HashMap<Long, Long> timeouts = new HashMap<>();
 
   public void register(long id, PrivateMessageData data, long timeout) {
     dataMap.put(id, data);
@@ -27,8 +27,15 @@ public class PrivateChatResponseWaiter {
     Bukkit.getScheduler().runTaskTimer(plugin, () -> {
       for (long id : new HashSet<>(timeouts.keySet())) {
         if (timeouts.get(id) < System.currentTimeMillis()) {
-          dataMap.remove(id);
+          PrivateMessageData data = dataMap.remove(id);
           timeouts.remove(id);
+
+          if (data != null) {
+            Player p = Bukkit.getPlayer(data.getSentPlayerName());
+            if (p != null) {
+              p.sendMessage(ChatColor.YELLOW + "[Error] " + ChatColor.RED + "個人チャットの送信に失敗しました");
+            }
+          }
         }
       }
     }, 10L, 10L);
@@ -50,5 +57,8 @@ public class PrivateChatResponseWaiter {
 
     sentPlayer.sendMessage(message);
     plugin.getLogger().info("[Private-Chat] " + ChatColor.stripColor(message));
+
+    dataMap.remove(id);
+    timeouts.remove(id);
   }
 }


### PR DESCRIPTION
* メッセージに対して登録した処理がエラーを出すと全てのチャットが停止するバグを修正 ( #40 )
* 個人チャットが届かなかった場合の表示を適用
* 運営が実際には届いていないチャットが見えてしまうバグを修正