### PR TITLE
:sparkles: コマンド経由のチャンネルメッセージ送信に対応

### DIFF
--- a/src/main/java/net/azisaba/ryuzupluginchat/RyuZUPluginChat.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/RyuZUPluginChat.java
@@ -16,6 +16,7 @@ import net.azisaba.ryuzupluginchat.command.VCCommand;
 import net.azisaba.ryuzupluginchat.config.RPCConfig;
 import net.azisaba.ryuzupluginchat.discord.DiscordHandler;
 import net.azisaba.ryuzupluginchat.discord.DiscordMessageConnection;
+import net.azisaba.ryuzupluginchat.listener.ChannelMsgFromCommandListener;
 import net.azisaba.ryuzupluginchat.listener.ChatListener;
 import net.azisaba.ryuzupluginchat.listener.HideAllListener;
 import net.azisaba.ryuzupluginchat.listener.JoinQuitListener;
@@ -98,6 +99,7 @@ public final class RyuZUPluginChat extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new JoinQuitListener(this), this);
     getServer().getPluginManager().registerEvents(new OutdatedCommandCaptureListener(this), this);
     getServer().getPluginManager().registerEvents(new LunaChatHideCommandListener(this), this);
+    getServer().getPluginManager().registerEvents(new ChannelMsgFromCommandListener(this), this);
     getServer().getPluginManager().registerEvents(new HideAllListener(this), this);
 
     registerCommands();

--- a/src/main/java/net/azisaba/ryuzupluginchat/listener/ChannelMsgFromCommandListener.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/listener/ChannelMsgFromCommandListener.java
@@ -1,0 +1,76 @@
+package net.azisaba.ryuzupluginchat.listener;
+
+import com.github.ucchyocean.lc3.LunaChat;
+import com.github.ucchyocean.lc3.channel.Channel;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import net.azisaba.ryuzupluginchat.RyuZUPluginChat;
+import net.azisaba.ryuzupluginchat.message.data.ChannelChatMessageData;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+@RequiredArgsConstructor
+public class ChannelMsgFromCommandListener implements Listener {
+
+  private final RyuZUPluginChat plugin;
+
+  private final List<String> chCommandList =
+      Arrays.asList(
+          "/ch", "/lunachat:ch", "/lc", "/lunachat:lc", "/lunachat", "/lunachat:lunachat");
+
+  private final List<String> lunaChatSubCommands =
+      Arrays.asList(
+          "create",
+          "join",
+          "leave",
+          "list",
+          "info",
+          "log",
+          "accept",
+          "deny",
+          "hide",
+          "unhide",
+          "invite",
+          "mute",
+          "unmute",
+          "kick",
+          "ban",
+          "pardon",
+          "remove",
+          "moderator",
+          "option");
+
+  @EventHandler
+  public void onCommand(PlayerCommandPreprocessEvent e) {
+    String message = e.getMessage();
+    String[] labelAndArgs = message.split(" ");
+    if (labelAndArgs.length <= 2 || !chCommandList.contains(labelAndArgs[0].toLowerCase())) {
+      return;
+    }
+
+    if (lunaChatSubCommands.contains(labelAndArgs[1].toLowerCase(Locale.ROOT))) {
+      return;
+    }
+
+    Channel ch = LunaChat.getAPI().getChannel(labelAndArgs[1]);
+    if (ch == null) {
+      return;
+    }
+
+    String chatMessage =
+        e.getMessage().substring(labelAndArgs[0].length() + labelAndArgs[1].length() + 1);
+
+    ChannelChatMessageData data =
+        plugin
+            .getMessageDataFactory()
+            .createChannelChatMessageData(e.getPlayer(), ch.getName(), chatMessage);
+    Bukkit.getScheduler()
+        .runTaskAsynchronously(plugin, () -> plugin.getPublisher().publishChannelChatMessage(data));
+
+    e.setCancelled(true);
+  }
+}


### PR DESCRIPTION
Closes #110 
デバッグするまでDraft

* 引数を2つ取れないLunaChatのサブコマンド(log, accept, deny等)の名前でチャンネルを作成した時、本家LunaChatで `/ch <ch名> <メッセージ>` を実行した時の挙動はどうなるか
* 本家LunaChatでチャンネル名の指定が Case Insensitive かどうか