### PR TITLE
:bug: /ch (チャンネル) (メッセージ)で先頭にスペースが入るバグの修正

### DIFF
--- a/src/main/java/net/azisaba/ryuzupluginchat/listener/ChannelMsgFromCommandListener.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/listener/ChannelMsgFromCommandListener.java
@@ -62,7 +62,7 @@ public class ChannelMsgFromCommandListener implements Listener {
     }
 
     String chatMessage =
-        e.getMessage().substring(labelAndArgs[0].length() + labelAndArgs[1].length() + 1);
+        e.getMessage().substring(labelAndArgs[0].length() + labelAndArgs[1].length() + 1).trim();
 
     ChannelChatMessageData data =
         plugin


### PR DESCRIPTION
Fixes #127 