### PR TITLE
Add default-disable-private-chat-inspect config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.azisaba</groupId>
   <artifactId>RyuZUPluginChat</artifactId>
-  <version>4.0.2</version>
+  <version>4.1.0</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/src/main/java/net/azisaba/ryuzupluginchat/config/RPCConfig.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/config/RPCConfig.java
@@ -36,6 +36,8 @@ public class RPCConfig {
   private String discordBotToken;
   private String vcCommandLunaChatChannel;
 
+  private boolean defaultDisablePrivateChatInspect;
+
   private final List<DiscordMessageConnection> messageConnections = new ArrayList<>();
 
   public void load() {
@@ -74,6 +76,8 @@ public class RPCConfig {
     }
 
     vcCommandLunaChatChannel = conf.getString("discord.vc-command-lunachat-channel", null);
+
+    defaultDisablePrivateChatInspect = conf.getBoolean("default-disable-private-chat-inspect", false);
 
     ConfigurationSection section = conf.getConfigurationSection("discord.connections");
     if (section == null) {

--- a/src/main/java/net/azisaba/ryuzupluginchat/listener/JoinQuitListener.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/listener/JoinQuitListener.java
@@ -29,6 +29,10 @@ public class JoinQuitListener implements Listener {
             20L * 3L);
 
     plugin.getHideAllInfoController().refreshHideAllInfoAsync(p.getUniqueId());
+
+    if (plugin.getRpcConfig().isDefaultDisablePrivateChatInspect()) {
+      plugin.getPrivateChatInspectHandler().setDisable(p.getUniqueId(), true);
+    }
   }
 
   @EventHandler

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,3 +34,4 @@ discord:
         enable: true
       private:
         enable: true
+default-disable-private-chat-inspect: false


### PR DESCRIPTION
Lifeサーバーだと滅多に必要にならないためデフォルトでsilentをオンにできるconfigを追加。デフォルトはfalse(今までと同じ仕様で動く)。trueにすると参加時に毎回`/rpc silent`を打ったようにsilentモードを自動でオンにする。

## Alternatives

- `/rpc silent`の状態を保存する
- このPRと上の両方