### PR TITLE
feat: Add AsyncPublish(Channel|Global|Private)MessageEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.azisaba</groupId>
   <artifactId>RyuZUPluginChat</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/src/main/java/net/azisaba/ryuzupluginchat/command/HideListCommand.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/command/HideListCommand.java
@@ -64,7 +64,7 @@ public class HideListCommand implements CommandExecutor, TabCompleter {
                       new TextComponent(Messages.getFormattedPlainText(p, "command.hidelist.tooltip", name))
                   })
           );
-          textName.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/unhide " + name));
+          textName.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/unhide " + name));
           text.addExtra(textName);
           p.spigot().sendMessage(text);
         });

--- a/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishChannelMessageEvent.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishChannelMessageEvent.java
@@ -1,0 +1,28 @@
+package net.azisaba.ryuzupluginchat.event;
+
+import net.azisaba.ryuzupluginchat.message.data.ChannelChatMessageData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class AsyncPublishChannelMessageEvent extends AsyncMessageEvent<ChannelChatMessageData> {
+  private static final HandlerList HANDLER_LIST = new HandlerList();
+
+  public AsyncPublishChannelMessageEvent(@NotNull ChannelChatMessageData message) {
+    super(message, Collections.emptySet());
+  }
+
+  @Override
+  public @NotNull HandlerList getHandlers() {
+    return HANDLER_LIST;
+  }
+
+  @SuppressWarnings("unused")
+  @NotNull
+  public static HandlerList getHandlerList() {
+    return HANDLER_LIST;
+  }
+}

--- a/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishGlobalMessageEvent.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishGlobalMessageEvent.java
@@ -1,0 +1,28 @@
+package net.azisaba.ryuzupluginchat.event;
+
+import net.azisaba.ryuzupluginchat.message.data.GlobalMessageData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class AsyncPublishGlobalMessageEvent extends AsyncMessageEvent<GlobalMessageData> {
+  private static final HandlerList HANDLER_LIST = new HandlerList();
+
+  public AsyncPublishGlobalMessageEvent(@NotNull GlobalMessageData message) {
+    super(message, Collections.emptySet());
+  }
+
+  @Override
+  public @NotNull HandlerList getHandlers() {
+    return HANDLER_LIST;
+  }
+
+  @SuppressWarnings("unused")
+  @NotNull
+  public static HandlerList getHandlerList() {
+    return HANDLER_LIST;
+  }
+}

--- a/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishPrivateMessageEvent.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/event/AsyncPublishPrivateMessageEvent.java
@@ -1,0 +1,28 @@
+package net.azisaba.ryuzupluginchat.event;
+
+import net.azisaba.ryuzupluginchat.message.data.PrivateMessageData;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class AsyncPublishPrivateMessageEvent extends AsyncMessageEvent<PrivateMessageData> {
+  private static final HandlerList HANDLER_LIST = new HandlerList();
+
+  public AsyncPublishPrivateMessageEvent(@NotNull PrivateMessageData message) {
+    super(message, Collections.emptySet());
+  }
+
+  @Override
+  public @NotNull HandlerList getHandlers() {
+    return HANDLER_LIST;
+  }
+
+  @SuppressWarnings("unused")
+  @NotNull
+  public static HandlerList getHandlerList() {
+    return HANDLER_LIST;
+  }
+}

--- a/src/main/java/net/azisaba/ryuzupluginchat/redis/MessagePublisher.java
+++ b/src/main/java/net/azisaba/ryuzupluginchat/redis/MessagePublisher.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import net.azisaba.ryuzupluginchat.RyuZUPluginChat;
+import net.azisaba.ryuzupluginchat.event.AsyncPublishChannelMessageEvent;
+import net.azisaba.ryuzupluginchat.event.AsyncPublishGlobalMessageEvent;
+import net.azisaba.ryuzupluginchat.event.AsyncPublishPrivateMessageEvent;
 import net.azisaba.ryuzupluginchat.message.JsonDataConverter;
 import net.azisaba.ryuzupluginchat.message.data.ChannelChatMessageData;
 import net.azisaba.ryuzupluginchat.message.data.GlobalMessageData;
@@ -23,6 +26,9 @@ public class MessagePublisher {
   private final String groupName;
 
   public boolean publishGlobalMessage(GlobalMessageData data) {
+    if (!new AsyncPublishGlobalMessageEvent(data).callEvent()) {
+      return false;
+    }
     String jsonMessage;
     try {
       jsonMessage = converter.convertIntoString(data);
@@ -37,6 +43,9 @@ public class MessagePublisher {
   }
 
   public boolean publishPrivateMessage(PrivateMessageData data) {
+    if (!new AsyncPublishPrivateMessageEvent(data).callEvent()) {
+      return false;
+    }
     String jsonMessage;
     try {
       jsonMessage = converter.convertIntoString(data);
@@ -51,6 +60,9 @@ public class MessagePublisher {
   }
 
   public boolean publishChannelChatMessage(ChannelChatMessageData data) {
+    if (!new AsyncPublishChannelMessageEvent(data).callEvent()) {
+      return false;
+    }
     String jsonMessage;
     try {
       jsonMessage = converter.convertIntoString(data);


### PR DESCRIPTION
`Async(Channel|Global|Private)MessageEvent`では複数サーバーでlistenして一つのデータベースに送信するプラグインが存在するときに重複してしまうため、publish時に発火するeventを追加